### PR TITLE
Mark's suggested revisions

### DIFF
--- a/v0.2.md
+++ b/v0.2.md
@@ -358,7 +358,9 @@ The MINT is invalid if `remaining_mint_allowed` exceeds the following value: (in
 &lt;transaction_type: 'MINT'&gt; (4 bytes, ascii)<BR>
 &lt;token_id&gt; (32 bytes)<BR>
 &lt;mint_baton_vout&gt; (0 bytes or 1 byte between 0x02-0xff)<BR>
-&lt;additional_token_quantity&gt; (8 byte integer)</td>
+&lt;additional_token_quantity&gt; (8 byte integer)<br/>
+&lt;remaining_mint_allowed&gt; (optional, 8 byte integer)
+  </td>
     <td>0</td>
     <td>0</td>
   </tr>

--- a/v0.2.md
+++ b/v0.2.md
@@ -1,10 +1,10 @@
 ![Simple Ledger Protocol](slplogo.png)
 
-# SLP: A token system for Bitcoin Cash 
+# SLP: A token system for Bitcoin Cash
 
 ### Spec version 0.2
 
-## Authors 
+## Authors
 
 Jonald Fyookball, James Cramer, Unwriter, Mark B. Lundeberg, Calin Culianu, Ryan X. Charles
 
@@ -16,7 +16,7 @@ Andrew Stone, for the token descriptor and baton ideas
 
 Dexx7, for code review and ideas
 
-## Table of Contents 
+## Table of Contents
 
 
 [SECTION I: BACKGROUND](#section-i-background)<BR>
@@ -29,7 +29,7 @@ Dexx7, for code review and ideas
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Simplicity and Consensus](#simplicity-and-consensus)<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Why SPV-friendly permissionless tokens are difficult](#why-spv-friendly-permissionless-tokens-are-difficult)<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Hybrid Security Model](#hybrid-security-model)<BR>
- 
+
 [SECTION II: PROTOCOL DESCRIPTION](#section-ii-protocol-description)<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;[Protocol Overview](#protocol-overview)<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;[Consensus Model](#consensus-model)<BR>
@@ -38,15 +38,15 @@ Dexx7, for code review and ideas
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Considerations](#considerations)<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;[Transaction Detail](#transaction-detail)<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Formatting](#formatting)<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Token Genesis Transaction](#token-genesis-transaction)<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Token Minting Transaction](#token-minting-transaction)<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Spend (Transfer) Transaction](#spend-transaction)<BR>
-&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Checksum Commitment Transaction](#checksum-commitment-transaction)<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[INIT - Token Genesis Transaction](#init---token-genesis-transaction)<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[MINT - Extended Minting Transaction](#mint---extended-minting-transaction)<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[TRAN - Spend Transaction](#tran---spend-transaction)<BR>
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[COMM - Checksum Commitment Transaction](#comm---checksum-commitment-transaction)<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Examples](#examples)<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;[Transaction Validation Security Model](#transaction-validation-security-model)<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;[Token Address Format](#token-address-format)<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[SLP Addr](#slp-addr)<BR>
- 
+
 [SECTION III: FURTHER ANALYSIS](#section-iii-further-analysis)<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;[Wallet Implementation](#wallet-implementation)<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Balance and History](#balance-and-history)<BR>
@@ -62,9 +62,9 @@ Dexx7, for code review and ideas
 &nbsp;&nbsp;&nbsp;&nbsp;[Appendix A: Regulated Security Tokens](#appendix-a-regulated-security-tokens)<BR>
 &nbsp;&nbsp;&nbsp;&nbsp;[Copyright](#copyright)
 
- 
+
 # SECTION I: BACKGROUND
- 
+
 # Introduction
 
 We begin with the premise that Bitcoin Cash needs a system for handling tradable or redeemable tokens.  We base this premise on the myriad of possible use cases and the billions of dollars of market capitalization that currently exist on platforms such as Ethereum.
@@ -76,15 +76,15 @@ Therefore, we are motivated to present our own solution.  The key to its potenti
 # Summary
 
 
-Simple Ledger Protocol (SLP) uses the meta data in OP_RETURN for the issuance and transfer of tokens in conjunction with standard transaction outputs that each represent a number of token units specified by the sender. Consensus on the interpretation of the OP_RETURN outputs is achieved by token users and market participants adhering to a prescribed set of simple rules. 
+Simple Ledger Protocol (SLP) uses the meta data in OP_RETURN for the issuance and transfer of tokens in conjunction with standard transaction outputs that each represent a number of token units specified by the sender. Consensus on the interpretation of the OP_RETURN outputs is achieved by token users and market participants adhering to a prescribed set of simple rules.
 
 
 Because SLP builds on the transaction chain of the existing Bitcoin framework, users can easily verify transactions with SPV/lite wallets within practical boundaries.  Full validation of a transaction back to its token genesis is possible by supplementing existing transaction-retrieval infrastructure with integration of SLP consensus rules.
 
 
-# Use Cases 
+# Use Cases
 
-A plethora of use cases for tokens has been detailed by others and does not require a long discussion here.   Uses include stocks, securities, registries, smart properties, utility tokens, contracts, coupons, bonds, demand deposits, local currencies, representation of physical assets, and many more. 
+A plethora of use cases for tokens has been detailed by others and does not require a long discussion here.   Uses include stocks, securities, registries, smart properties, utility tokens, contracts, coupons, bonds, demand deposits, local currencies, representation of physical assets, and many more.
 
 # Requirements
 
@@ -122,61 +122,61 @@ Here is a chart comparing primary token properties:
 
 
 Other aspects are noted below: how multiple tokens can interact (e.g., can they appear in the same transaction, allowing token-token direct swaps?); how much customization is available to token properties at issuance; and any other notable extras / unusual features.
- 
-![Table 2](table2.png)
- 
-# Design Philosophy and Challenges 
 
-Understanding the thinking behind the SLP protocol may assist in its evaluation.  
+![Table 2](table2.png)
+
+# Design Philosophy and Challenges
+
+Understanding the thinking behind the SLP protocol may assist in its evaluation.
 
 ## Simplicity and Consensus
 
 Our most formative principle is that of simplicity.  We found most of the previous attempts to introduce Bitcoin token proposals to be overcomplicated, which hinders both community support as well as implementation efforts and integration.
 
-But there is an even more important reason to keep things as simple as possible, and that is to facilitate consensus.  The base layer of Bitcoin can accommodate a complex set of consensus rules because Proof-of-Work ensures high byzantine fault tolerance.  In other words, if miners’ implementations do not agree, the incompatibility is revealed quickly and the non-integrous data is expunged.  
+But there is an even more important reason to keep things as simple as possible, and that is to facilitate consensus.  The base layer of Bitcoin can accommodate a complex set of consensus rules because Proof-of-Work ensures high byzantine fault tolerance.  In other words, if miners’ implementations do not agree, the incompatibility is revealed quickly and the non-integrous data is expunged.
 
 By contrast, meta data is not miner validated and there is no clear separation between valid and invalid data.  This creates an environment of low fault tolerance.  For token schemes that rely on central authorities or signers, this is not necessarily an issue.  However, for permissionless systems like SLP, the only apparent way to mitigate this problem is to keep the rules simple and clear.
 
 ## Why SPV-friendly permissionless tokens are difficult
 
 Without modifying the base Bitcoin protocol, supporting SPV wallets is challenging.  This is because invalid Bitcoin transactions are excluded from the blockchain, but invalid second-layer transactions are not.  Thus, you cannot use the SPV security technique of checking the merkle branch to ensure the transaction is included in a block.
- 
+
 To prove a token transfer is valid, it is necessary to validate all prior transfers starting with the token genesis.  It would be advantageous to validate a token transaction with a high degree of certainty using only a subset of prior transactions.  Unfortunately, this does not appear possible because an attacker can cheaply create a chain of transactions to fool a recipient into believing an incoming transaction is valid when it is not.
 
-We considered the possibility of attempting to prevent this attack with various commitment schemes, requiring transactions to point back to prior transactions.  However, this idea is ineffective because all links can be spoofed, regardless of whether they pointed to fake transactions on the false chain or real transactions on the valid chain. Thus, foul play would only be detectable at the exact place of divergence, which could be anywhere.  
+We considered the possibility of attempting to prevent this attack with various commitment schemes, requiring transactions to point back to prior transactions.  However, this idea is ineffective because all links can be spoofed, regardless of whether they pointed to fake transactions on the false chain or real transactions on the valid chain. Thus, foul play would only be detectable at the exact place of divergence, which could be anywhere.
 
 ## Hybrid Security Model
 
-Other various commitment schemes were considered and discarded.  Finally, we concluded that the simplest solution is best:  Users can validate the transfer of token ownership as far back as they choose, with the understanding that if they do not verify completely then it is theoretically possible for an attacker to create a longer attack chain. 
+Other various commitment schemes were considered and discarded.  Finally, we concluded that the simplest solution is best:  Users can validate the transfer of token ownership as far back as they choose, with the understanding that if they do not verify completely then it is theoretically possible for an attacker to create a longer attack chain.
 
 It is an acceptable limitation to have partial SPV-compatible validation, IF it is supplemented with an infrastructure-based solution providing full validation.  We will discuss the security model in detail in a subsequent section.
 
-# SECTION II: PROTOCOL DESCRIPTION 
+# SECTION II: PROTOCOL DESCRIPTION
 
- 
 
-# Protocol Overview 
 
-The protocol defines 4 types of token transactions, which are contained within the OP_RETURN meta data of standard Bitcoin Cash transactions.  
+# Protocol Overview
 
-The first 2 token transaction types (genesis and minting) define and issue the token.  The third transaction type is the most common (send); it allows users to transfer tokens. 
+The protocol defines 4 types of token transactions, which are contained within the OP_RETURN meta data of standard Bitcoin Cash transactions.
+
+The first 2 token transaction types (genesis and minting) define and issue the token.  The third transaction type is the most common (send); it allows users to transfer tokens.
 The final transaction type (checksum commitment) is a supplement to the basic consensus model.
 
 The protocol also defines 4 consensus rules that determine the validity of a token send transaction (see Consensus Rules section below).
 
-Rather than coloring coins directly, SLP represents one or more token units with a BCH unspent output.  Since Bitcoin transactions usually have multiple outputs, the OP_RETURN message must specify how many tokens are being assigned to which outputs.  
+Rather than coloring coins directly, SLP represents one or more token units with a BCH unspent output.  Since Bitcoin transactions usually have multiple outputs, the OP_RETURN message must specify how many tokens are being assigned to which outputs.
 
 SLP transactions can contain multiple inputs and outputs which typically would correspond to those in the Bitcoin transaction they are carried in (although its possible to have additional *non*-SLP inputs and outputs in the same transaction).  Note that you cannot send multiple *types* of SLP tokens in the same transaction.  Also, it is possible to lose tokens if a token-containing output is improperly spent.
 
-# Consensus Model  
+# Consensus Model
 
-SLP utilizes a model that could be described as **Proof-of-Work/Proof-of-Trust**.   
+SLP utilizes a model that could be described as **Proof-of-Work/Proof-of-Trust**.
 
 Meta data, while prunable, is still part of Bitcoin blocks -- timestamped and ordered in the immutable ledger via Proof-of-Work. However, like most OP_RETURN based approaches, what SLP sees as valid data is not segregated from what it considers invalid.  Although unambiguously ordered to prevent double-spending, the data must be filtered according to a set of rules that all participants agree on.
 
 In many ways, this is not different than how Bitcoin itself operates.  Users must stay together on the same set of consensus rules to maintain their network effect.  The possibility to diverge is always present, with the market being the ultimate judge of how much value each ruleset holds.
 
-In a pure Proof-of-Work model, byzantine fault tolerance is achieved via economic incentives combined with incompatible-by-design sets of data.  By contrast, SLP relies on a minimalistic set of rules overlayed onto the support of the PoW backbone.   
+In a pure Proof-of-Work model, byzantine fault tolerance is achieved via economic incentives combined with incompatible-by-design sets of data.  By contrast, SLP relies on a minimalistic set of rules overlayed onto the support of the PoW backbone.
 
 With transaction ordering taken care of by the underlying Bitcoin Cash blockchain, users simply have to use the same rules as a matter of convention.  Those rules will be defined by the concordance of:
 
@@ -188,24 +188,24 @@ c) token issuers
 
 ## Checksum commitments
 
-Token issuers should publish periodic hash commitments of valid transactions in accordance with this specification, which provides a "Proof of Trust". 
+Token issuers should publish periodic hash commitments of valid transactions in accordance with this specification, which provides a "Proof of Trust".
 
-It is important to understand that the checksums are part of the overall consensus model but are **NOT** part of the consensus *rules* per se.   If this sounds paradoxical, understand that the blockchain data and protocol rules are paramount.  The issuer is usually (but not always) just the most important economic actor. 
- 
+It is important to understand that the checksums are part of the overall consensus model but are **NOT** part of the consensus *rules* per se.   If this sounds paradoxical, understand that the blockchain data and protocol rules are paramount.  The issuer is usually (but not always) just the most important economic actor.
+
 Commitments by the issuer serve as a "proof of responsibility".  If the issuer is not capable of producing an accurate summary of transactions under the rules of the protocol, it will be readily apparent, and market forces will react appropriately.  As a side benefit, checksum commitments create a modest barrier to entry, dissuading the lowest-effort actors from creating worthless tokens.
- 
+
 # Consensus Rules
- 
+
 For a BCH transaction to contain a valid SLP transaction, it must follow all of the following rules:
 
 1. The sum of the token "meta outputs" (token amounts specified in OP_RETURN) must not exceed the sum of the VALID (non-ignored) token “meta inputs” (token amounts previously specified in OP_RETURN for each coin, assuming the transactions that spent them were also valid SLP transactions).
 
-2. There must be one and only one OP_RETURN output, and it must be vout 0. 
+2. There must be one and only one OP_RETURN output, and it must be vout 0.
 
 3. The OP_RETURN output must conform precisely to this specification (see "transaction detail" section)
 
 4. Transaction inputs are ignored if they represent a token_id different from the token_id specified in the OP_RETURN output. (In other words, if the inputs’ previous transaction’s OP_RETURN’s token_id does not match the current OP_RETURN’s token_id). The same applies not just to token_id but also the version.
- 
+
 
 ## Considerations
 
@@ -223,304 +223,323 @@ c) A token's genesis defines the protocol version it is using.  This is less fle
 
 ## Formatting
 
-SLP uses a restricted form of bitcoin script after the OP_RETURN to encode data chunks as bitcoin script PUSH codes.  Each separately pushed component (or field) inside the OP_RETURN payload is denoted in the subsequent sections using angle brackets (e.g., &lt;xyz&gt;) The following rules apply to the various data push payloads within each OP_RETURN transaction types (i.e., INIT, MINT, TRAN, and COMM):
+SLP uses a restricted form of bitcoin script after the OP_RETURN to encode variable length data chunks as bitcoin script PUSH operations.  Each separately pushed component (or field) inside the OP_RETURN payload is denoted in the subsequent sections using angle brackets (e.g., &lt;xyz&gt;) The following rules apply to the various data push payloads within each OP_RETURN transaction types (i.e., INIT, MINT, TRAN, and COMM). Messages violating these rules shall be judged entirely invalid under SLP consensus:
 
-1. Each field must be preceded by a valid Bitcoin script data push opcode.
+1. The script must be valid bitcoin script. Each field must be preceded by a valid Bitcoin script data push opcode. Truncated scripts (ending mid-push) are disallowed.
 
-2. Each field presented inside the OP_RETURN payload must match a specified byte size value or range of values.  In the subsequent sections in this specification, this is denoted in parenthesis following the variable name in angle brackets.
+2. Each field presented inside the OP_RETURN payload must match the byte size and/or value indicated in parentheses.
 
-3. The push opcodes 0x01 - 0x4e are all permitted for any chunk, as long as the number of bytes indicated by the push code conforms to the field size in the spec and to the data being pushed. This means, for example, that it is possible to push a 4-byte chunk (like lokad ID) in four different ways: 0x04 [data], 0x4c 0x04 [data], 0x4d 0x04 0x00 [data], or 0x4e 0x04 0x00 0x00 0x00 [data].
+3. The push opcodes 0x01 to 0x4e are all permitted for any chunk, as long as the number of bytes indicated by the push code conforms to the field size in the spec and to the data being pushed. This means, for example, that it is valid to push a 4-byte chunk (like the Lokad ID) in four different ways: 0x04 [chunk], 0x4c 0x04 [chunk], 0x4d 0x04 0x00 [chunk], or 0x4e 0x04 0x00 0x00 0x00 [chunk].
 
-4. The empty-push opcode 0x00 (OP_0) and 1-byte literal push opcodes 0x4f-0x60 (OP_1 through OP_16 and OP_1NEGATE) are considered invalid under SLP consensus rules. For example, it is invalid to use 0x58 to push the number '8' in the 1-byte decimals field of the INIT transaction, even though in normal bitcoin script the opcode 0x58 is effectively equivalent to 0x01 0x08  (push 8). For this reason some standard bitcoin script decompilers, that treat all push opcodes on equal footing, must not be used for parsing SLP transactions.
+4. It is forbidden to use the empty-push opcode 0x00 (OP_0) or 1-byte literal push opcodes 0x4f-0x60 (OP_1 through OP_16 and OP_1NEGATE) anywhere in the OP_RETURN. For example, it is invalid to use 0x58 to push the number '8' in the 1-byte decimals field of the INIT transaction, even though in normal bitcoin script the opcode 0x58 is effectively equivalent to 0x01 0x08  (push 8). For this reason some standard bitcoin script decompilers, that treat all push opcodes on equal footing, must not be used for parsing SLP transactions.
 
-5. Empty fields are permitted however you cannot use opcode 0x00 for this purpose. Rather, you may use 0x4c 0x00, or 0x4d 0x00 0x00, or 0x4e 0x00 0x00 0x00 0x00.
+5. Some fields permit an empty push (length-0 chunk) however you cannot use opcode 0x00 for this purpose. Rather, you may use 0x4c 0x00, or 0x4d 0x00 0x00, or 0x4e 0x00 0x00 0x00 0x00.
 
-6. All number fields will use big endian hexadecimal encoding (using left padded zeroes as needed).
+6. All integer fields are unsigned and use big-endian encoding, i.e., an amount of 1000 in an indicated 8-byte field shall be pushed as the byte array [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x03, 0xE8].
 
-7. Extraneous appendages are prohibited.  Any extra data coming after an otherwise-valid payload will then invalidate the transaction.
+7. Optional fields are omitted by simply leaving out the push. If an optional field is included, all preceding optional fields must be included as well.
 
-8. All parts of the OP_RETURN payload must conform precisely or the entire transaction is considered invalid under SLP consensus rules.  For example, if a transaction has 5 outputs, and the fifth output has only 7 bytes instead of 8, then the previous 4 outputs effectively burn the tokens because the entire transaction is invalid.  The same is true if an improper push code is used.  The message has to be perfect.
- 
-All user-optional string fields within the INIT OP_RETURN payload should be encoded in format specified within parenthesis in the sections below.  Consensus validity does not depend on successful text decoding, and therefore does not rely on any specific implementation of decoding or encoding.
+8. Extraneous appendages are prohibited.  Any unexpected data coming after an otherwise-valid payload will invalidate the transaction.
 
-Any field listed with a specified upper byte size limit of "X" is only restricted by the upper size limit of an OP_RETURN (i.e., 223 bytes at the time of this writing)
- 
-## Token Genesis Transaction
+9. The message has to be perfect in its entirety. For example, if a transaction has 5 outputs, and the fifth output has only 7 bytes instead of 8, then the previous 4 outputs effectively burn the tokens because the entire transaction is invalid.
 
-This is the first transaction which defines the properties, metadata and initial quantity of the token.  The token is uniquely identified by the token genesis transaction hash which is hereinafter referred to as "token_id".  
+10. String fields within the INIT OP_RETURN payload have a recommended character encoding, however it is not required for validity that these byte arrays are able to be decoded. String fields of (in principle) unlimited length are listed with an upper limit of "∞", however in practice they are limited by the ScriptPubKey length restriction (223 bytes at the time of this writing).
 
-The genesis transaction includes an initial minting.  The issuer’s bitcoin address (scriptPubKey) used to create the token can be of any type (e.g., P2PKH, P2PK, P2SH, etc.).
+## INIT - Token Genesis Transaction
 
-Token Types:
+This is the first transaction which defines the properties, metadata and initial mint quantity of the token. The token is thereafter uniquely identified by the token genesis transaction hash which is referred to as `token_id`.
+
+`token_type` indicates the SLP sub-protocol:
 
 * 1 - Permissionless Token Type
-
 * 2 - Reserved for Security Token Type (see [Appendix A](#bookmark=id.t5t1povi0m8m))
-
 * 3 - Reserved for Voting Token Type
-
 * 4 - Reserved for Ticketing Token Type
 
-This specification generally describes the rules and operation of the Permissionless Token Type (1).  The genesis transaction for a token includes an initial mint supply.  Future token supply increases are made possible if an issuer marks a special output UTXO as a "baton" that can be passed along and used for future minting authority. If the baton is not present, then the genesis is a provable one-time issuance token. If mint_baton_vout refers to a nonexistent output, the transaction is valid but the baton is lost. A valid token transaction will always have OP_RETURN at vout: 0.
+This document specifies the rules and operation of the Permissionless Token Type (1) only. Tokens of different types cannot be mixed, and so future specifications of other token types will not affect the consensus validity of type 1.
 
+`mint_baton_vout`: Future token supply increases are made possible if the genesis endows a specific transaction output with a "minting baton" that can be passed along and used for future minting (using 'MINT' transactions, see below). If `mint_baton_vout` is not present or refers to a nonexistent output, then the baton does not exist and the token provably has a one-time issuance.
+
+`decimals`: indicates that 1 token is divisible into 10^`decimals` base units. SLP messages store whole numbers indicating token amounts as measured in the base unit, analogous to how bitcoin transactions store BCH amounts measured in the base unit 'satoshis'. With a token FOO having `decimals` of 6 indicated in the genesis, for example, the quantity 12.53 FOO (as displayed in wallet software) would be represented by 12530000 base units (as 8 bytes, hex 0000000000bf3150). A `decimals` of 8 would give the same divisibility as bitcoin, whereas 0 would give indivisible tokens.
+
+The genesis transaction includes an initial minting of `initial_token_mint_quantity` base units, placed on the second transaction output (vout=1).
+
+`remaining_mint_allowed` is used to restrict the total possible future minting that can occur using the mint baton.
+
+**Transaction inputs**: Any number of inputs or content of inputs, in any order.
+
+**Transacation outputs**:
 <table>
+<tr>
+  <td><b>v<sub>out</sub></b></td>
+  <td><b>ScriptPubKey ("Address")</b></td>
+  <td><b>BCH<br/>amount</b></td>
+  <td><b>Implied token amount<br/>(base units)</b></td>
+</tr>
   <tr>
-    <td>INPUTS</td>
-    <td></td>
-    <td>OUTPUTS</td>
-    <td>BCH Transferred</td>
-  </tr>
-  <tr>
-    <td>George any UTXO(s)</td>
-    <td></td>
-   <td>OP_RETURN<sup>1</sup><BR>
-    &lt;Lokad identifier: \x00SLP&gt; (4 bytes, ascii)<sup>2</sup><BR>
-&lt;version / token_type&gt; (1 to 2 bytes)<BR>
-&lt;SLP cmd: INIT&gt; (4 bytes, ascii)<BR>
-&lt;token_ticker&gt; (0 to 8 bytes, suggested utf-8)<BR>
-&lt;token_name&gt; (0 to X bytes, suggested utf-8)<BR>
-&lt;token_document_url&gt; (0 to X bytes, suggested ascii)<BR>
-&lt;token_document_hash&gt; (0 bytes or 32 bytes)<BR>
-    &lt;unit_decimal_place&gt; (1 byte between 0x00-0x09)<sup>3</sup><BR>
-&lt;mint_baton_vout&gt; (0 bytes, or 1 byte between 0x02-0xff)<BR>
-&lt;initial_token_mint_quantity&gt; (8 bytes, for vout:1)</td>
+    <td>0</td>
+   <td>
+   OP_RETURN<br/>
+   &lt;lokad_id: '\x00SLP'&gt; (4 bytes, ascii)<sup>1</sup><br/>
+   &lt;token_type: 1&gt; (1 to 2 byte integer)<br/>
+   &lt;transaction_type: 'INIT'&gt; (4 bytes, ascii)<br/>
+   &lt;token_ticker&gt; (0 to 8 bytes, suggested utf-8)<sup>2</sup><br/>
+   &lt;token_name&gt; (0 to ∞ bytes, suggested utf-8)<sup>2</sup><br/>
+   &lt;token_document_url&gt; (0 to ∞ bytes, suggested ascii)<sup>2</sup><br/>
+   &lt;token_document_hash&gt; (0 bytes or 32 bytes)<sup>2</sup><br/>
+   &lt;decimals&gt; (1 byte in range 0x00-0x09)<sup>3</sup><br/>
+   &lt;mint_baton_vout&gt; (0 bytes, or 1 byte in range 0x02-0xff)<br/>
+   &lt;initial_token_mint_quantity&gt; (8 byte integer)<br/>
+   &lt;remaining_mint_allowed&gt; (optional, 8 byte integer)
+   </td>
+    <td>0</td>
     <td>0</td>
   </tr>
+
   <tr>
-    <td></td>
-    <td></td>
-    <td>Initial Mint Receiver (George or anyone)</td>
-    <td>dust limit or change</td>
+    <td>1</td>
+    <td>Initial mint receiver</td>
+    <td>any</td>
+    <td>initial_token_mint_quantity</td>
   </tr>
-  
+
   <tr>
-    <td></td>
-    <td></td>
-    <td>Optional "baton" to enable future mints 
-(anyone)</td>
-    <td>dust limit or change</td>
+    <td>...</td>
+    <td>Any</td>
+    <td>any</td>
+    <td>0</td>
+  </tr>
+
+  <tr>
+    <td>M</td>
+    <td>(M=mint_baton_vout) Mint baton receiver</td>
+    <td>any</td>
+    <td>0 <br/> + 'baton'</td>
+  </tr>
+
+  <tr>
+    <td>...</td>
+    <td>Any</td>
+    <td>any</td>
+    <td>0</td>
   </tr>
 </table>
 
-<sup>1. The token ticker, document url, and document hash fields listed within this transaction should follow the format proposed by Andrew Stone in the [GROUP token proposal](https://docs.google.com/document/d/1X-yrqBJNj6oGPku49krZqTMGNNEWnUJBRFjX7fJXvTs/edit#heading=h.o2xp4d9v0yor).</sup>
+<sup>1. The Lokad identifier is registered as “0x00534c50” (the ascii equivalent of SLP). Inquiries and additional information about the Lokad system of OP_RETURN protocol identifiers can be found at https://github.com/Lokad/Terab maintained by Joannes Vermorel.</sup>
 
-<sup>2. The Lokad identifier is registered as “0x00534c50” (the ascii equivalent of SLP). Inquiries and additional information about the Lokad system of OP_RETURN protocol identifiers can be found at https://github.com/Lokad/Terab maintained by Joannes Vermorel.</sup>
+<sup>2. The token ticker, document url, and document hash fields listed within this transaction should follow the format proposed by Andrew Stone in the [GROUP token proposal](https://docs.google.com/document/d/1X-yrqBJNj6oGPku49krZqTMGNNEWnUJBRFjX7fJXvTs/edit#heading=h.o2xp4d9v0yor).</sup>
 
-<sup>3. A token issuer may signal for their preferred number of decimal places that should be displayed within a wallet implementation by specifying the number of digits right of the decimal point.  However, just like the unit of satoshis in Bitcoin token values are not divisible, but they can be displayed in various units of account. NOTE: There is no requirement for a wallet implementation to use this unit preference.</sup>
+## MINT - Extended Minting Transaction
+### (used with "baton" to increase supply)
 
+Subsequent minting transactions of `additional_token_quantity` can be performed by spending the "minting baton" UTXO in a special MINT transaction, described here. Note that this could be done by someone other than the INIT issuer, if the baton minting authority had been passed to another address.
 
-## Token Minting Transaction 
-### (used with optional "baton" only to increase supply)
+As with INIT, the MINT allows to end the baton, or further pass on the baton to future mint operations: if `mint_baton_vout` is empty or refers to a nonexistent vout, the transaction is valid but the baton is lost. This makes it possible to prove end-of-minting capabilities for a token even after several minting events (it is impossible to duplicate this baton as that would require double-spending the transaction output associated with the baton).
 
-This is a special transaction used to increase the supply of a token if a baton was created in either the Genesis or Minting transaction.  If there is no such baton output then subsequent minting transactions are not possible for the token, making it possible to prove end-of-minting capabilities for a token.  These subsequent minting transactions can be performed by the owner of the baton UTXO, which does not need to be the initial token issuer.  For example, the Issuer may pass the minting authority along to someone else. The MINT allows to further pass on the baton to future mint operations, or to end the baton. If mint_baton_vout refers to a nonexistent vout, the transaction is valid but the baton is lost.
+The MINT is invalid if `remaining_mint_allowed` exceeds the following value: (input `remaining_mint_allowed`) − (this `additional_token_quantity`). If not specified, `remaining_mint_allowed` should be considered as infinite. This implies that:
+* If the baton input included `remaining_mint_allowed` then `remaining_mint_allowed` must be included.
+* If the baton input did not include `remaining_mint_allowed` then `remaining_mint_allowed` *may* be included (to restrict future mints).
 
+**Transaction inputs**: Any number of inputs or content of inputs, in any order, but must include a 'baton' transaction output from a previous INIT (or MINT) that is valid and of matching `token_id`, `token_type`.
+
+**Transacation outputs**:
 <table>
+<tr>
+  <td><b>v<sub>out</sub></b></td>
+  <td><b>ScriptPubKey ("Address")</b></td>
+  <td><b>BCH<br/>amount</b></td>
+  <td><b>Implied token amount<br/>(base units)</b></td>
+</tr>
   <tr>
-    <td>INPUTS</td>
-    <td></td>
-    <td>OUTPUTS</td>
-    <td>BCH Transferred</td>
-  </tr>
-  <tr>
-    <td>Baton Owner from a Previous GENESIS or MINT</td>
-    <td></td>
+  <td>0</td>
     <td>OP_RETURN<BR>
-&lt;lokad id: \x00SLP&gt; (4 bytes, ascii)<BR>
-&lt;version / token_type&gt; (1 to 2 bytes)<BR>
-&lt;SLP cmd: MINT&gt; (4 bytes, ascii)<BR>
+&lt;lokad_id: '\x00SLP'&gt; (4 bytes, ascii)<BR>
+&lt;token_type: 1&gt; (1 to 2 byte integer)<BR>
+&lt;transaction_type: 'MINT'&gt; (4 bytes, ascii)<BR>
 &lt;token_id&gt; (32 bytes)<BR>
 &lt;mint_baton_vout&gt; (0 bytes or 1 byte between 0x02-0xff)<BR>
-&lt;additional_token_quantity&gt; (8 bytes, for vout:1)</td>
+&lt;additional_token_quantity&gt; (8 byte integer)</td>
+    <td>0</td>
     <td>0</td>
   </tr>
   <tr>
-    <td></td>
-    <td></td>
-    <td>Token Mint Receiver (anyone)</td>
-    <td>dust limit or change</td>
+    <td>1</td>
+    <td>Token mint receiver</td>
+    <td>any</td>
+    <td>additional_token_quantity</td>
   </tr>
-   
+
   <tr>
-    <td></td>
-    <td></td>
-    <td>Optional "baton“ to enable future mints (anyone)</td>
-    <td>dust limit or change</td>
+    <td>...</td>
+    <td>Any</td>
+    <td>any</td>
+    <td>0</td>
+  </tr>
+
+  <tr>
+    <td>M</td>
+    <td>Mint baton receiver<br/>(M=mint_baton_vout)</td>
+    <td>any</td>
+    <td>0<br/> + 'baton'</td>
   </tr>
   <tr>
-    <td>Other UTXOs if needed</td>
-    <td></td>
-    <td></td>
-    <td></td>
+    <td>...</td>
+    <td>Any</td>
+    <td>any</td>
+    <td>0</td>
   </tr>
+
 </table>
 
 
-## Spend Transaction
+## TRAN - Spend Transaction
 ### (Transfer)
-The following transaction format will be used to transfer tokens from one token holding UTXO(s) to new token holding UTXO(s).  The UTXOs associated with unspent tokens will be used within the transaction input and, just like the BCH attached to these UTXOs, will be considered totally spent after this transaction is accepted by the network. Tokens will be assigned to new UTXOs vout: 1 up to vout: 19 as indicated within the OP_RETURN statement.  Any number of additional BCH-only outputs will be allowed.  A BCH-only output can come before token outputs, but a token quantity of 0 must be specified for the respective vout index.
+The following transaction format will be used to transfer tokens from one token holding UTXO(s) to new token holding UTXO(s).  The UTXOs associated with unspent tokens will be used within the transaction input and, just like the BCH attached to these UTXOs, will be considered totally spent after this transaction is accepted by the network. Tokens will be assigned to new UTXOs vout=1 up to vout=19 as indicated within the OP_RETURN statement.  Any number of additional BCH-only outputs will be allowed.  A BCH-only output can come before token outputs, but a token quantity of 0 must be specified for the respective vout index.
 
-Token inputs and BCH-only inputs may come in any order.
+**Transaction inputs**: Any number of inputs or content of inputs, in any order, but must include sufficient tokens coming from valid token transactions of matching `token_id`, `token_type`.
 
+**Transaction outputs**:
 <table>
   <tr>
-    <td>INPUTS (Alice)</td>
-    <td></td>
-    <td>OUTPUTS</td>
-    <td>BCH Transferred</td>
+    <td><b>v<sub>out</sub></b></td>
+    <td><b>ScriptPubKey ("Address")</b></td>
+    <td><b>BCH<br/>amount</b></td>
+    <td><b>Implied token amount<br/>(base units)</b></td>
   </tr>
   <tr>
-    <td>Alice UTXO #1-N<BR> w/ token_id tokens </td>
-    <td></td>
-    <td>OP_RETURN<BR>
-&lt;lokad id: \x00SLP&gt; (4 bytes, ascii)<BR>
-&lt;version / token_type&gt; (1 to 2 bytes)<BR>
-&lt;SLP cmd: TRAN&gt; (4 bytes, ascii)<BR>
-&lt;token_id&gt; (32 bytes)<BR>
-&lt;token_output_quantity1&gt; (8 bytes, for vout:1)<BR>
-...<BR>
-&lt;token_output_quantityN&gt; (optional, 8 bytes, vout:N)<BR>
-...<BR>
-&lt;token_output_quantity19&gt; (optional, 8 bytes, vout:19 max)</td>
     <td>0</td>
+    <td>OP_RETURN<BR>
+&lt;lokad id: '\x00SLP'&gt; (4 bytes, ascii)<BR/>
+&lt;token_type: 1&gt; (1 to 2 byte integer)<BR/>
+&lt;transaction_type: 'TRAN'&gt; (4 bytes, ascii)<BR/>
+&lt;token_id&gt; (32 bytes)<BR/>
+&lt;token_output_quantity1&gt; (<b>required</b>, 8 byte integer)<BR/>
+&lt;token_output_quantity2&gt; (optional, 8 byte integer)<BR/>
+...<BR/>
+&lt;token_output_quantity19&gt; (optional, 8 byte integer)</td>
+  <td>0</td>
+  <td>0</td>
   </tr>
   <tr>
-    <td></td>
-    <td></td>
-    <td>Receiver 1 (Bob1)</td>
-    <td>dust limit</td>
+    <td>1</td>
+    <td>Receiver 1</td>
+    <td>any</td>
+    <td>token_output_quantity1</td>
   </tr>
   <tr>
-    <td></td>
-    <td></td>
     <td>...</td>
-    <td></td>
-  </tr>
-  <tr>
-    <td></td>
-    <td></td>
-    <td>Receiver N (BobN)</td>
-    <td>dust limit</td>
-  </tr>
-  <tr>
-    <td></td>
-    <td></td>
     <td>...</td>
-    <td></td>
+    <td>any</td>
+    <td>...</td>
   </tr>
   <tr>
-    <td></td>
-    <td></td>
-    <td>Receiver 19 (Bob19)</td>
-    <td>dust limit</td>
+    <td>N</td>
+    <td>Receiver N<br/>(N = number of token_output_quantities provided)</td>
+    <td>any</td>
+    <td>token_output_quantityN</td>
   </tr>
   <tr>
-    <td></td>
-    <td></td>
-    <td>Optional for change (anyone)</td>
-    <td>change</td>
-  </tr>
-  <tr>
-    <td>Other UTXOs </td>
-    <td></td>
-    <td></td>
-    <td></td>
+    <td>...</td>
+    <td>Any</td>
+    <td>any</td>
+    <td>0</td>
   </tr>
 </table>
 
-## Checksum Commitment Transaction
+## COMM - Checksum Commitment Transaction
 
-As previously discussed, a token issuer should make a regular commitments of the hash of previous transactions made for the token.  Although this is not part of the consensus rules, it demonstrates that the issuer is in agreement with those rules and allows a user to verify that the issuer is indisputably operating according to the token’s consensus ruleset. 
+As previously discussed, a token issuer should make regular commitments of the SHA-256 hash of previous transactions made for this token. Although this is not part of the consensus rules (commitments may occur outside of the token transaction graph, and commitment data is never used in consensus rules), it allows a user to verify that the issuer is accurately honoring the token's consensus rules. This increases confidence that tokens will be judged as expected at the time of redemption.
 
-Checksum hashes should be published by the issuer well after the block so that no double spends can occur and contradict the hash.  Issuers should wait 100 blocks before publishing.  
+Initial implementations will focus on supporting the consensus-based forms of validation, and so at this time the exact format for the commitment document is not specified. The general ideas will be:
 
-The hash may be computed using a merklix tree if the token’s set, aggregating the token count on its branches such as each node is H(left || right || token_count). This ensures that the presence and/or absence of some token can be proven at any given point. It is also possible to audit the token in circulation. 
+* The committed information will be in regards to only the transactions that exist in the blockchain leading up to and including the block with hash `for_bitcoin_block_hash`. (If the block is orphaned, users should ignore this commitment.)
 
-These commitments enable checkpoint based validation (discussed later).  The exact format of the checksum is not defined in this version of the protocol spec.  Initial implementations are likely to focus on supportting the consensus-based forms of validation primarily.  
+* The committed set of SLP information will be hashed using an *ordered* merkle tree (such as [merklix](https://www.deadalnix.me/2016/09/24/introducing-merklix-tree-as-an-unordered-merkle-tree-on-steroid/)) that allows lite clients to obtain short merkle proofs of the presence *or absence* of a given SLP item (presence indicating valid, absence indicating invalid).
 
+* These commitments will thus enable checkpoint based validation, discussed later. From this set it is also possible to audit the total number of tokens in circulation (tokens issued minus tokens burned) for that block.
+
+* The set items will relate to one specific `token_id`, and might be transactions, or transaction outputs; all, or only unspent. The set will be carefully chosen to satisfy the above requirements with a minimal size.
+
+**Transaction inputs**: At least one input should use an address controlled by a trusted validator (could be original issuer, or a respected member of the token community) and this input should sign with SIGHASH_ALL.
+
+**Transaction outputs**:
 <table>
   <tr>
-    <td>INPUTS (George)</td>
-    <td></td>
-    <td>OUTPUTS</td>
-    <td>BCH Transferred</td>
+    <td><b>v<sub>out</sub></b></td>
+    <td><b>ScriptPubKey ("Address")</b></td>
+    <td><b>BCH<br/>amount</b></td>
   </tr>
   <tr>
-    <td>George or trusted validator, any UTXO</td>
-    <td></td>
-    <td>OP_RETURN<BR>
-&lt;lokad id: \x00SLP&gt; (4 bytes, ascii)<BR>
-&lt;version / token_type&gt; (1 to 2 bytes)<BR>
-&lt;SLP cmd: COMM&gt; (4 bytes, ascii) <BR>
-&lt;token_id&gt; (32 bytes)<BR>
-&lt;for_bitcoin_block_height&gt; (8 bytes)<BR>
-&lt;for_bitcoin_block_hash&gt; (32 bytes)<BR>
-&lt;token_txn_set_commitment&gt; (32 bytes)<BR>
-&lt;txn_set_data_url&gt; (up to X bytes, ascii)<BR>
-&lt;validator_pubkey&gt; (33 bytes)<BR>
-&lt;validator_signature&gt; (64 bytes)</td>
+    <td>0</td>
+    <td>
+    OP_RETURN<br/>
+    &lt;lokad_id: '\x00SLP'&gt; (4 bytes, ascii)<br/>
+    &lt;token_type: 1&gt; (1 to 2 byte integer)<br/>
+    &lt;transaction_type: 'COMM'&gt; (4 bytes, ascii) <br/>
+    &lt;token_id&gt; (32 bytes)<br/>
+    &lt;for_bitcoin_block_hash&gt; (32 bytes)<br/>
+    &lt;token_txn_set_hash&gt; (32 bytes)<br/>
+    &lt;txn_set_data_url&gt; (0 to ∞ bytes, ascii)<br/>
+    <i>[to be determined]</i>
+  </td>
     <td>0</td>
   </tr>
   <tr>
-    <td></td>
-    <td></td>
-    <td>Optional for change (anyone)  </td>
-    <td>change</td>
+    <td>...</td>
+    <td>Any</td>
+    <td>any</td>
   </tr>
-  
+
 </table>
 
 ## Examples
 
 **INIT Transaction**
- 
+
 https://blockchair.com/bitcoin-cash/transaction/430788724aca748a66759005a98ba2c40f5cd5087cc4bdd69d9cb44b4ac701c5
 
-```SCRIPT:6A0400534C50010104494E4954045553445423546574686572204C74642E20555320646F6C6C6172206261636B656420746F6B656E734168747470733A2F2F7465746865722E746F2F77702D636F6E74656E742F75706C6F6164732F323031362F30362F546574686572576869746550617065722E70646620DB4451F11EDA33950670AAF59E704DA90117FF7057283B032CFAEC77793139160108010208002386F26FC10000```
+SCRIPT: ``6A0400534C50010104494E4954045553445423546574686572204C74642E20555320646F6C6C6172206261636B656420746F6B656E734168747470733A2F2F7465746865722E746F2F77702D636F6E74656E742F75706C6F6164732F323031362F30362F546574686572576869746550617065722E70646620DB4451F11EDA33950670AAF59E704DA90117FF7057283B032CFAEC77793139160108010208002386F26FC10000``
 
 **MINT Transaction**
 
 https://blockchair.com/bitcoin-cash/transaction/6e8a4b29e8264186733656e7dfcac266c521180ee75ae8413c66fdd714e97414
 
-```SCRIPT:6A0400534C500101044D494E5420430788724ACA748A66759005A98BA2C40F5CD5087CC4BDD69D9CB44B4AC701C5010208002386F26FC10000```
+SCRIPT: ``6A0400534C500101044D494E5420430788724ACA748A66759005A98BA2C40F5CD5087CC4BDD69D9CB44B4AC701C5010208002386F26FC10000``
 
 **TRAN Transaction**
 
 https://blockchair.com/bitcoin-cash/transaction/938faffd93f2e9b2a0be37d579b2d920a64c611f980d70a77563d869e39d816d
 
-```SCRIPT:6A0400534C500101045452414E20430788724ACA748A66759005A98BA2C40F5CD5087CC4BDD69D9CB44B4AC701C508000009184E72A00008004704CC910F6000```
+SCRIPT: ``6A0400534C500101045452414E20430788724ACA748A66759005A98BA2C40F5CD5087CC4BDD69D9CB44B4AC701C508000009184E72A00008004704CC910F6000``
 
 **COMM Transaction**
 
-https://blockchair.com/bitcoin-cash/transaction/77cac182d46df928b839bae95d654a24e0a6a6536e779ce1dcf85c8d5c52f4dd
+[to be determined]
 
-```SCRIPT:6A0400534C50010104434F4D4D20430788724ACA748A66759005A98BA2C40F5CD5087CC4BDD69D9CB44B4AC701C520000000000000000000E34B6259F69534FA02FFD5AE2C0C9338BCC49BF7C89DE82036DAB7BB622AD19767923F8E268C90EE037E2FBB5E4CF18931908AE27CC4C7BD4C002103B33754A520D1A551A2CCAE6598DDDBF50EA9E1D8E048DF2E36A2FA11DEB3CE5341304402201B6B55BB5A349E75AF5E516D500528ACCEAF6CED6D7A66CF7D369C98FF6E981102203724DE46B01C605C895E9E5445314D2E2653DA6124589DFA1C5041```
- 
+
 # Transaction Validation Security Model
 
-Users have several methods for validating incoming transactions: 
+Users have several methods for validating incoming transactions:
 
-**1. Full self-validation.**  The user checks each relevant UTXO input from the current transaction leading all the way back to genesis. This is the most complete and secure method since it captures the complete proof DAG, but also the most burdensome.  Depending on the implementation, wallets could parse transactions individually, or they could request the DAG set of transactions from a server that gives a complete validation. 
+1. **Full self-validation.**  The user checks each relevant UTXO input from the current transaction leading all the way back to genesis. This is the most complete and secure method since it captures the complete proof DAG, but also the most burdensome.  Depending on the implementation, wallets could parse transactions individually, or they could request the DAG set of transactions from a server that gives a complete validation.<p>The feasibility of full self-validation is only limited by the size of the transaction graph  (see figure below). It does not require a fully validating Bitcoin node.
 
-The feasibility of full self-validation is only limited by the size of the transaction graph  (see figure below). It does not require a fully validating Bitcoin node.
+2. **Limited self-validation.** The user checks each relevant UTXO, working backward from the current transaction, but does not go all the way back to the genesis token transaction.  This provides validation except for when an attacker creates a longer chain than is being validated for.
 
+3. **Wallet-integrated proxy validation.**  A wallet can query (via API) an infrastructure service such as BitDB to determine if an SLP transaction is valid.
 
-**2. Limited self-validation.** The user checks each relevant UTXO, working backward from the current transaction, but does not go all the way back to the genesis token transaction.  This provides validation except for when an attacker creates a longer chain than is being validated for.
+4. **Non-wallet proxy validation.**  Typically, users check their transactions on block explorers.   There is plethora of both token and non-token supporting block explorers in the broader cryptocurrency ecosystem.  BCH token block explorers are expected to flourish.
 
-**3. Wallet-integrated proxy validation.**  A wallet can query (via API) an infrastructure service such as BitDB to determine if an SLP transaction is valid.
+5. **Checkpoint based validation.**  The user checks each relevant UTXO input from the current transaction leading all the way back to a checkpoint provided by a trusted token token validator using a checksum commitment transaction. This involves a degree of trust in the token’s validator, however its actions are all recorded in the blockchain and attached to it’s identity, so it is easy to exclude a validator that’s been proven fraudulent.
 
-**4. Non-wallet proxy validation.**  Typically, users check their transactions on block explorers.   There is plethora of both token and non-token supporting block explorers in the broader cryptocurrency ecosystem.  BCH token block explorers are expected to flourish.
-
-**5. Checkpoint based validation.**  The user checks each relevant UTXO input from the current transaction leading all the way back to a checkpoint provided by a trusted token token validator using a checksum commitment transaction. This involves a degree of trust in the token’s validator, however its actions are all recorded in the blockchain and attached to it’s identity, so it is easy to exclude a validator that’s been proven fraudulent.
-
-Transactions form a directed acyclic graph (DAG).  Full validation terminates at the token genesis transaction.
+Transactions form a directed acyclic graph (DAG).  Full validation terminates at the token genesis transaction which is a self-evidently valid transaction.
 
 ![Transaction DAG](image_0.png)
 
 **Figure 1.** An illustration of the SLP token transaction graph for a token where the issuer has used multiple minting transactions to increase token supply. The genesis transaction includes the initial mint transaction. If no "baton" is included with the genesis transaction then future supply increases are not possible.
 
-The validation methods listed above can be used together in various combinations and have a synergistic effect as part of a *trust-but-verify* model which trusts proxies for full validation and verifies with partial self validation.  
+The validation methods listed above can be used together in various combinations and have a synergistic effect as part of a *trust-but-verify* model which trusts proxies for full validation and verifies with partial self validation.
 
-A good token wallet should always perform some kind of full validation.  This best practice creates a low probability of success for an attack, which discourages attackers --  further increasing the effectiveness of partial validation.  Verifying the information from proxies is possible to any chosen degree, and a client can check with multiple proxies or nodes until he’s convinced the SLP chain is valid. 
+A good token wallet should always perform some kind of full validation.  This best practice creates a low probability of success for an attack, which discourages attackers --  further increasing the effectiveness of partial validation.  Verifying the information from proxies is possible to any chosen degree, and a client can check with multiple proxies or nodes until he’s convinced the SLP chain is valid.
 
 Additionally, although an attack is not necessarily costly in fees, it may be costly in coordination efforts, because long chains of transactions need to be dispersed across the span of time to avoid being blatantly suspicious.
 
@@ -528,11 +547,11 @@ Additionally, although an attack is not necessarily costly in fees, it may be co
 
 The protocol’s consensus rules, security model, and operation are independent of any particular address encoding; it could be used in theory with legacy addresses or CashAddr addresses.
 
-However, using a new address format makes sense because it will greatly mitigate usability problems.  Specifically, it will help prevent users from accidentally spending a UTXO that has a token balance, which is likely to happen if users send tokens to a non token-aware wallet.  
+However, using a new address format makes sense because it will greatly mitigate usability problems.  Specifically, it will help prevent users from accidentally spending a UTXO that has a token balance, which is likely to happen if users send tokens to a non token-aware wallet.
 
 ## SLP Addr
 
-Following the design and nomenclature of [CashAddr](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md), SLP Addr will use the same encoding scheme except for its prefix -- substituting "SLP:" in place of “bitcoincash”. The URI prefix “simpleledger” is [untaken](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml). Since the prefix is part of the checksum (even if omitted in display), an SLP Addr will be an invalid encoding for an application expecting a Cash Addr address, and vice-versa.  
+Following the design and nomenclature of [CashAddr](https://github.com/bitcoincashorg/bitcoincash.org/blob/master/spec/cashaddr.md), SLP Addr will use the same encoding scheme except for its prefix -- substituting “simpleledger:” in place of “bitcoincash:”. The URI prefix “simpleledger” [has been taken for this project](https://www.iana.org/assignments/uri-schemes/uri-schemes.xhtml). Since the prefix is part of the checksum (even if omitted in display), an SLP Addr will be an invalid encoding for an application expecting a Cash Addr address, and vice-versa.
 The temporary incompatibility between a normal Bitcoin Cash wallet and an SLP wallet can be handled by the SLP wallet providing an address converter.  This is an acceptable trade-off to create the desired separation.
 
 **Bip39 and Electrum Seeds**
@@ -541,9 +560,9 @@ Hierarchical deterministic wallets can be used for tokens.  To keep addresses se
 
 However, wallets can also choose to simply expect users to have a different wallet file for tokens vs regular BCH funds.
 
-# SECTION III: FURTHER ANALYSIS 
+# SECTION III: FURTHER ANALYSIS
 
-# Wallet Implementation  
+# Wallet Implementation
 
 SPV and/or lite wallets such as Electron Cash or the Bitcoin.com wallet can be modified to support tokens in addition to regular BCH.  Several key considerations for such modification are described below.
 
@@ -551,9 +570,9 @@ SPV and/or lite wallets such as Electron Cash or the Bitcoin.com wallet can be m
 
 Wallets can be modified to incorporate token validation schemes (as discussed above in previous sections) to compute a token balance for each address the wallet manages, in addition to usual BCH balances that a wallet normally displays.
 
-The wallet’s engine will receive a transaction history for the addresses it manages in the usual way, and in addition it will parse any transactions it sees with the relevant OP_RETURN messages (either genesis transactions or send/receive transactions).  It will then apply consensus and validation to filter out invalid "noise" or fake token transactions and collate the valid results appropriately to compute a balance and history for each token that it sees and for each address that it manages.  
+The wallet’s engine will receive a transaction history for the addresses it manages in the usual way, and in addition it will parse any transactions it sees with the relevant OP_RETURN messages (either genesis transactions or send/receive transactions).  It will then apply consensus and validation to filter out invalid "noise" or fake token transactions and collate the valid results appropriately to compute a balance and history for each token that it sees and for each address that it manages.
 
-It should be noted that since anyone can mint any arbitrary new token using SLP, only a certain subset of extant tokens on the blockchain will have any value or be of interest to a particular user. 
+It should be noted that since anyone can mint any arbitrary new token using SLP, only a certain subset of extant tokens on the blockchain will have any value or be of interest to a particular user.
 
 Optionally, the user should be offered the capability to only view tokens to which they have "subscribed", or which they consider “official” or “of interest” (for example by explicitly specifying the minting transaction hash of a particular token they wish to follow, or perhaps by opting-out of any particular tokens they aren’t interested in monitoring).  Thus, wallet software can be configurable to suppress the display of potential token ‘noise’ for a particular set of wallet addresses.
 
@@ -561,25 +580,25 @@ Optionally, the user should be offered the capability to only view tokens to whi
 
 The most important principle that every token-wallet implementation must observe is protection against losing tokens.  Tokens are lost when a token-containing UTXO is spent on a non-token transaction (or a wrongly-typed token).
 
-Wallets can use a seperate set of key/address pairs, perhaps with a distinct derivation path as previously discussed.  The best implementations will even avoid spending outputs with *any* OP_RETURN data, as they could be used for other token schemes or blockchain applications.  
+Wallets can use a seperate set of key/address pairs, perhaps with a distinct derivation path as previously discussed.  The best implementations will even avoid spending outputs with *any* OP_RETURN data, as they could be used for other token schemes or blockchain applications.
 
-Even if wallets maintain a separate set of addresses for SLP, it’s still possible to end up with token-holding UTXOs that also contain significant BCH (or vice-versa). Should the user wish to spend some of that BCH while leaving the token balance unchanged, wallet implementations should be able to handle this by sending change appropriately.  
+Even if wallets maintain a separate set of addresses for SLP, it’s still possible to end up with token-holding UTXOs that also contain significant BCH (or vice-versa). Should the user wish to spend some of that BCH while leaving the token balance unchanged, wallet implementations should be able to handle this by sending change appropriately.
 
 Token spends should be managed by the wallet intelligently so as to minimize the amount of BCH associated with a token UTXO (preferably keeping token UTXOs at or close to the aforementioned dust limit).
 
 ## Funding Transaction Fees
 
-Wallets may find that their token-holding UTXOs do not contain sufficient BCH funds to craft a transaction that spends a token.  When building an implementation, developers need to plan for making available extra funds to pay for fees, while keeping the boundary entact between different types of unspent outputs. 
+Wallets may find that their token-holding UTXOs do not contain sufficient BCH funds to craft a transaction that spends a token.  When building an implementation, developers need to plan for making available extra funds to pay for fees, while keeping the boundary entact between different types of unspent outputs.
 
 ## Sending and Receiving
 
-Wallet software is free to offer any user experience it sees fit for managing tokens. Spending screens can be anything from very simple forms to more complex per-UTXO breakdowns.  This specification leaves it up to the wallet implementor to decide how best to manage their users’ control over tokens. 
+Wallet software is free to offer any user experience it sees fit for managing tokens. Spending screens can be anything from very simple forms to more complex per-UTXO breakdowns.  This specification leaves it up to the wallet implementor to decide how best to manage their users’ control over tokens.
 
 ## Handling multiple token types
 
-Any number of different token_ids can be sent to the same SLP address, so in principle a single address could have thousands of distinct token balances on it. Only the UTXOs are limited to a single token_id. 
+Any number of different token_ids can be sent to the same SLP address, so in principle a single address could have thousands of distinct token balances on it. Only the UTXOs are limited to a single token_id.
 
-One suggestion is to create a drop-down selector that allows users to choose the token_id of interest.  Other token_ids are not forgotten, they are just not displayed and their UTXOs are prevented from getting involved. 
+One suggestion is to create a drop-down selector that allows users to choose the token_id of interest.  Other token_ids are not forgotten, they are just not displayed and their UTXOs are prevented from getting involved.
 
 Validation should be deferred for uninteresting token_ids as it can take a lot of time and bandwidth.
 
@@ -603,11 +622,11 @@ The reference implementation uses a breadth-first search, seeking to prioritize 
 <sup>4. Note on double spends: SLP validators should be designed to tolerate double spends (multiple TxIns referring to a single TxOut) as these are technically "SLP valid", even though the bitcoin network should never allow these double spends to appear in the mempool or blockchain.</sup>
 
 
-# Proxies  
+# Proxies
 
-To support lite wallets, what is needed is a full node with code that watches all "SLP"-tagged transactions in mempool/blocks and classifies them as valid/invalid, as they roll in. 
+To support lite wallets, what is needed is a full node with code that watches all "SLP"-tagged transactions in mempool/blocks and classifies them as valid/invalid, as they roll in.
 
-Due to the SLP design, this classification can be done immediately and permanently, as validity is independent of block confirmation / block reorganizations (Only miner confirmations prevent double spends). 
+Due to the SLP design, this classification can be done immediately and permanently, as validity is independent of block confirmation / block reorganizations (Only miner confirmations prevent double spends).
 
 Clients can query the proxy database and get a judgement on any given transaction; however it is up to the querier to decide whether or not to trust the judgement. Ideally, The judgement should be cryptographically signed and kept as a way to demonstrate bad behaviour by the proxy.
 
@@ -626,36 +645,36 @@ In fact, BitDB is the likeliest candidate to universally support SLP tokens; the
 2. Whenever there's a new block, we look for a condition (are there any new OP_RETURNs that match the protocol?)
 
 
-3. When we find them, we use them to construct a graph database. The property graph consists of vertices which represent Bitcoin addresses, and edges which represent token transfers among the vertices. The edges contain the transfer amount as well as the original Bitcoin transaction hash which caused the state transition, which can be used to verify the authenticity by cross-referencing with any Bitcoin node. 
+3. When we find them, we use them to construct a graph database. The property graph consists of vertices which represent Bitcoin addresses, and edges which represent token transfers among the vertices. The edges contain the transfer amount as well as the original Bitcoin transaction hash which caused the state transition, which can be used to verify the authenticity by cross-referencing with any Bitcoin node.
 
 
 4. The function for determining whether a token is spendable applies the SLP validation procedure by running a query on the graph to find all incoming edges and outgoing edges, and comparing the sum value of the transfer amounts. The logic then becomes:
 
 **IF (sum(outgoing edges) + current_token_transfer_amount < sum(incoming edges)) THEN return True**
 
-# Economic Implications 
+# Economic Implications
 
 There are several economic-related questions regarding different aspects of the protocol and what they imply economically.  Here are some key conclusions:
 
-1. SLP transactions are carried in Bitcoin transactions and thus do not change economic incentives for their confirmation by miners. 
+1. SLP transactions are carried in Bitcoin transactions and thus do not change economic incentives for their confirmation by miners.
 
 2. Prevalent use of metadata in transactions can be paid for using the standard miner fees with per-byte pricing.
 
-3. Pruned metadata can be archived by issuers and other token stakeholders.  In fact, this is part of the protocol’s "proof-of-trust" where the issuer will be required to maintain the set of metadata associated with the issuer’s token so that he can make regular commitments to prove the issuer agrees with the consensus ruleset for the token type.  
+3. Pruned metadata can be archived by issuers and other token stakeholders.  In fact, this is part of the protocol’s "proof-of-trust" where the issuer will be required to maintain the set of metadata associated with the issuer’s token so that he can make regular commitments to prove the issuer agrees with the consensus ruleset for the token type.
 
 4. Archival data retains full Proof-of-Work security as it is and will always be an immutable as part of the merkle tree.
 
 5. The Bitcoin Cash UTXO set will grow as a result of token usage.  However, this is not fundamentally different from UTXO set growth from non-token usage, and is a necessary effect that comes from more blockchain usage in general, which is desired.
 
-# Appendix A: Regulated Security Tokens 
+# Appendix A: Regulated Security Tokens
 
-Tokenization presents a huge opportunity to bring more liquidity to the secondary trading marketplace for regulated securities which has traditionally suffered from long investor hold times and thus low liquidity for private placement securities.  
+Tokenization presents a huge opportunity to bring more liquidity to the secondary trading marketplace for regulated securities which has traditionally suffered from long investor hold times and thus low liquidity for private placement securities.
 
-The preceding SLP Token specification focused on purely permissionless tokens because they offer the most liberty to a token holder, meaning absolute control of the digital token is given to the token holder.   
+The preceding SLP Token specification focused on purely permissionless tokens because they offer the most liberty to a token holder, meaning absolute control of the digital token is given to the token holder.
 
 However, many private companies are not legally permitted to trade their company’s equity so freely due to a number of regulatory restrictions where the investor must be accredited and their identity must be known to the company.
 
-To solve this problem, several existing security token trading platforms have built their protocol and implementations to associate one or more whitelists of accredited investors with the security token.  These platforms then limit whom is allowed to buy and trade shares of company stock to the whitelist.  
+To solve this problem, several existing security token trading platforms have built their protocol and implementations to associate one or more whitelists of accredited investors with the security token.  These platforms then limit whom is allowed to buy and trade shares of company stock to the whitelist.
 
 The true power of these platforms lies in the buyer and seller market that is created by these curated whitelists which comply with a given private company’s regulatory jurisdiction.  This may offer a dramatic increase in liquidity for a company’s stock.  There is an entire ecosystem dedicated towards security tokens with whitelists.  Leading companies within the regulated security token ecosystem include [BlockTrade](https://blocktrade.com/), [PolyMath](https://polymath.network/), [Harbor](https://harbor.com/), [tzero](https://www.tzero.com/), and [0x protocol](https://0xproject.com/).
 
@@ -670,5 +689,3 @@ We have not created a specification for a securities token using whitelists at t
 # Copyright
 
 This protocol specification is published under the terms of the MIT license.
- 
-


### PR DESCRIPTION
Suggested changes over a wide variety of things.

- added remaining_mint_allowed
- 'Formatting' - slight rewording of things
- Transaction formats - changed table format, explained fields
- COMM transaction - removed some unnecessary fields that were pushing up byte size to near limit
- COMM transaction - alternate description of planned approach
- fix old 'SLP:' prefix
- misc formatting

(a lot of the diff lines are extra whitespace stripping, so apologies for the extra noise)